### PR TITLE
Connect to libraries outside working directory

### DIFF
--- a/pysyncrosim/scenario.py
+++ b/pysyncrosim/scenario.py
@@ -430,11 +430,11 @@ class Scenario(object):
         if self.__env is None:
             try:
                 # fix this
-                fpath = os.path.join(os.getcwd(), self.library.name + ".temp",
-                                     os.listdir(self.library.name + ".temp")[0])
+                fpath = os.path.join(self.library.location + ".temp",
+                                     os.listdir(self.library.location + ".temp")[0])
             except (FileNotFoundError, IndexError):
                 
-                f_base_path = os.path.join(os.getcwd(), self.library.name + ".output")
+                f_base_path = os.path.join(self.library.location + ".output")
                 fpath = self.__find_output_fpath(f_base_path, datasheet)
 
         else:

--- a/pysyncrosim/scenario.py
+++ b/pysyncrosim/scenario.py
@@ -432,7 +432,7 @@ class Scenario(object):
                 # fix this
                 fpath = os.path.join(os.getcwd(), self.library.name + ".temp",
                                      os.listdir(self.library.name + ".temp")[0])
-            except IndexError:
+            except (FileNotFoundError, IndexError):
                 
                 f_base_path = os.path.join(os.getcwd(), self.library.name + ".output")
                 fpath = self.__find_output_fpath(f_base_path, datasheet)


### PR DESCRIPTION
Some scenario commands search for library in the working directory without checking the library location path. This PR fixes that issue and an unhandled error for libraries missing a *.temp folder.