### PR TITLE
Clean up references to loc attribute

### DIFF
--- a/pysyncrosim/helper.py
+++ b/pysyncrosim/helper.py
@@ -149,7 +149,7 @@ def library(name, session=None, package="stsim", addons=None, template=None,
     finally:
         
         if library_up_to_date is True:
-            return ps.Library(loc=loc, session=session)
+            return ps.Library(location=loc, session=session)
 
 def _delete_library(name, session=None, force=False):
     """

--- a/pysyncrosim/library.py
+++ b/pysyncrosim/library.py
@@ -76,7 +76,7 @@ class Library(object):
 
         Parameters
         ----------
-        loc : String
+        location : String
             Filepath to Library location on disk.
         session : Session
             pysyncrosim Session instance.


### PR DESCRIPTION
Two leftover references to the old `loc` attribute of `library` were removed form the codebase.